### PR TITLE
Add validation logs for game launch

### DIFF
--- a/action.php
+++ b/action.php
@@ -3,8 +3,13 @@ header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . 'GMT');
 header('Cache-Control: no-cache, must-revalidate');
 header('Pragma: no-cache');
 include("core/CAccount.php");
-if(!isset($_SESSION['sessid'])||!isset($_GET)||!isset($_POST))
-	header("Location: index.php");
+error_log("Game launch initiated");
+if(!isset($_SESSION['sessid'])||!isset($_GET)||!isset($_POST)){
+        error_log("Invalid session or request data during game launch");
+        header("Location: index.php");
+        exit;
+}
+error_log("Session and request data validated");
 ?>
 <?php
 if(isset($_GET["view"]) && $_GET["view"]=="avatarNotes"){
@@ -42,117 +47,136 @@ $ships = new CShips(true);
 ?>
 <?php 
 if(isset($_GET['action']) && isset($_GET['function'])) {
+ error_log("Processing GET action '".$_GET['action']."' with function '".$_GET['function']."'");
  switch($_GET['action']){
     case "transportOperations":
-	 if($_GET['function'] == "abortFleetOperation"){
-	  $transport->abortFleetOperation($_GET);
-	 }
-	break;
+         error_log("Executing transportOperations -> '".$_GET['function']."'");
+         if($_GET['function'] == "abortFleetOperation"){
+          $transport->abortFleetOperation($_GET);
+         }
+        break;
     case "Diplomacy":
-	 if($_GET['function'] == "saveAvatarNote"){
-	  //$account->saveAvatarNote($_GET['notes']);
-	 }
-	break;
+         error_log("Executing Diplomacy -> '".$_GET['function']."'");
+         if($_GET['function'] == "saveAvatarNote"){
+          //$account->saveAvatarNote($_GET['notes']);
+         }
+        break;
     case "WorldMap":
-	 if($_GET['function'] == "getJSONArea"){
-	  $island->getJSONArea($_GET);
-	 }
-	 else if($_GET['function'] == "getJSONIsland"){
-	  $island->getJSONIsland($_GET['x'], $_GET['y']);
-	 }
-	break;
- 	case "loginAvatar":
-	 if($_GET['function']=="login"){
-	  include("Templates/city.php");
-	 }
-	 if($_GET['function']=="logout"){
-	  $session->Logout();
-	 }
-	break;
-	case "CityScreen":  
+         error_log("Executing WorldMap -> '".$_GET['function']."'");
+         if($_GET['function'] == "getJSONArea"){
+          $island->getJSONArea($_GET);
+         }
+         else if($_GET['function'] == "getJSONIsland"){
+          $island->getJSONIsland($_GET['x'], $_GET['y']);
+         }
+        break;
+        case "loginAvatar":
+         error_log("Executing loginAvatar -> '".$_GET['function']."'");
+         if($_GET['function']=="login"){
+          include("Templates/city.php");
+         }
+         if($_GET['function']=="logout"){
+          $session->Logout();
+         }
+        break;
+        case "CityScreen":
+     error_log("Executing CityScreen -> '".$_GET['function']."'");
      switch($_GET['function']){
-	  case "build":
-	  case "upgradeBuilding":
-	   $building = new CBuilding;
-	   $building->procBuild($_GET);
-	  break;
-	  case "abortMilitaryConstruction":
-	   if(isset($_GET['type'])&&$_GET['type']=='army')
-	    $units->abortMilitaryConstruction($_GET);
-	   else 
-	    $ships->abortMilitaryConstruction($_GET);
-	  break;
-	  case "increaseTransporter":
-	   $city->increaseTransporter($_GET);
-	  break;
-	 }
-	break;
-	case "Advisor":
-	 if($_GET['function']=="doResearch"){
-	  $research->doResearch($_GET);
-	 }
-	break;
- 	default:break;
+          case "build":
+          case "upgradeBuilding":
+           $building = new CBuilding;
+           $building->procBuild($_GET);
+          break;
+          case "abortMilitaryConstruction":
+           if(isset($_GET['type'])&&$_GET['type']=='army')
+            $units->abortMilitaryConstruction($_GET);
+           else
+            $ships->abortMilitaryConstruction($_GET);
+          break;
+          case "increaseTransporter":
+           $city->increaseTransporter($_GET);
+          break;
+         }
+        break;
+        case "Advisor":
+         error_log("Executing Advisor -> '".$_GET['function']."'");
+         if($_GET['function']=="doResearch"){
+          $research->doResearch($_GET);
+         }
+        break;
+        default:
+         error_log("Unknown GET action '".$_GET['action']."'");
+        break;
  }
 }
 ?>
 
 <?php 
 if(isset($_GET['view'])) {
+ error_log("Loading view '".$_GET['view']."'");
  include("Templates/".$_GET['view'].".php");
 }
 ?>
 <?php 
 if(isset($_POST['action']) && isset($_POST['function'])) {
+ error_log("Processing POST action '".$_POST['action']."' with function '".$_POST['function']."'");
  switch($_POST['action']){
     case "Espionage":
-	 if($_POST['function'] == "buildSpy"){
-	  $city->buildSpy($_POST);
-	 }
-	break;
+         error_log("Executing Espionage -> '".$_POST['function']."'");
+         if($_POST['function'] == "buildSpy"){
+          $city->buildSpy($_POST);
+         }
+        break;
     case "transportOperations":
-	 if($_POST['function'] == "startColonization"){
-	  $transport->startColonization($_POST);
-	 }
-	break;
-	case "Options":
-	 if($_POST['function'] == "changeAvatarValues"){
-	  $account->changeAvatarValues($_POST);
-	 }
-	 if($_POST['function'] == "changeEmail"){
-	  $account->changeEmail($_POST);
-	 }
-	 header("Location: action.php?action=loginAvatar&function=login");
-	break;
- 	case "header":
-	 if($_POST['function'] == "changeCurrentCity"){
-	 $city->changeCurrentCity($_POST);
-	 }
-	break;
-	case "IslandScreen":
-	 include("Templates/".$_POST['function'].".php");
-	case "CityScreen":
-	 if($_POST['function'] == "buildUnits"){
-	  $units->buildUnits($_POST);
-	 }
-	 else if($_POST['function'] == "buildShips"){
-	  $ships->buildShips($_POST);
-	 }
-	 else if($_POST['function'] == "workerPlan"){
-	  include("Templates/workerPlan.php");
-	 }
-	 else if($_POST['function'] == "rename"){
-	   $city->renameCity($_POST);
-	   header("Location: action.php?view=townHall&id=".$city->cid."&position=0");
-	 }
-	 else if($_POST['function'] == "buyResearch"){
-	   $city->buyResearch($_POST);
-	 }
-	 else if($_POST['function'] == "assignWinePerTick"){
-	  $city->assignWinePerTick($_POST);
-	 }
-	break;
- 	default:break;
+         error_log("Executing transportOperations -> '".$_POST['function']."'");
+         if($_POST['function'] == "startColonization"){
+          $transport->startColonization($_POST);
+         }
+        break;
+        case "Options":
+         error_log("Executing Options -> '".$_POST['function']."'");
+         if($_POST['function'] == "changeAvatarValues"){
+          $account->changeAvatarValues($_POST);
+         }
+         if($_POST['function'] == "changeEmail"){
+          $account->changeEmail($_POST);
+         }
+         header("Location: action.php?action=loginAvatar&function=login");
+        break;
+        case "header":
+         error_log("Executing header -> '".$_POST['function']."'");
+         if($_POST['function'] == "changeCurrentCity"){
+         $city->changeCurrentCity($_POST);
+         }
+        break;
+        case "IslandScreen":
+         error_log("Executing IslandScreen -> '".$_POST['function']."'");
+         include("Templates/".$_POST['function'].".php");
+        case "CityScreen":
+         error_log("Executing CityScreen -> '".$_POST['function']."'");
+         if($_POST['function'] == "buildUnits"){
+          $units->buildUnits($_POST);
+         }
+         else if($_POST['function'] == "buildShips"){
+          $ships->buildShips($_POST);
+         }
+         else if($_POST['function'] == "workerPlan"){
+          include("Templates/workerPlan.php");
+         }
+         else if($_POST['function'] == "rename"){
+           $city->renameCity($_POST);
+           header("Location: action.php?view=townHall&id=".$city->cid."&position=0");
+         }
+         else if($_POST['function'] == "buyResearch"){
+           $city->buyResearch($_POST);
+         }
+         else if($_POST['function'] == "assignWinePerTick"){
+          $city->assignWinePerTick($_POST);
+         }
+        break;
+        default:
+         error_log("Unknown POST action '".$_POST['action']."'");
+        break;
  }
 }
 ?>

--- a/core/CAccount.php
+++ b/core/CAccount.php
@@ -135,11 +135,12 @@ class CAccount {
 		}
 	}
 	
-	private function Login() {
-		global $database,$session,$form;
-		if(!isset($_POST['user']) || $_POST['user'] == "") {
-			$form->addError("user",LOGIN_USR_EMPTY);
-		}
+        private function Login() {
+                global $database,$session,$form;
+                error_log("CAccount::Login attempt for user: ".(isset($_POST['user'])?$_POST['user']:'undefined'));
+                if(!isset($_POST['user']) || $_POST['user'] == "") {
+                        $form->addError("user",LOGIN_USR_EMPTY);
+                }
 		else if(!$database->checkExist($_POST['user'],0)) {
 			$form->addError("user",USR_NT_FOUND);
 		}
@@ -149,18 +150,20 @@ class CAccount {
 		else if(!$database->login($_POST['user'],$_POST['pw'])) {
 			$form->addError("pw",LOGIN_PW_ERROR);
 		}
-		if($form->returnErrors() > 0) {
-			$_SESSION['errorarray'] = $form->getErrors();
-			$_SESSION['valuearray'] = $_POST;
-			
-			header("Location: index.php");
-		}
-		else {
-			setcookie("COOKUSR",$_POST['user'],time()+COOKIE_EXPIRE,COOKIE_PATH);
-			$session->login($_POST['user']);
-			header("Location: action.php?action=loginAvatar&function=login");
-		}
-	}
+                if($form->returnErrors() > 0) {
+                        error_log("CAccount::Login failed for user: ".(isset($_POST['user'])?$_POST['user']:'undefined'));
+                        $_SESSION['errorarray'] = $form->getErrors();
+                        $_SESSION['valuearray'] = $_POST;
+
+                        header("Location: index.php");
+                }
+                else {
+                        error_log("CAccount::Login successful for user: ".$_POST['user']);
+                        setcookie("COOKUSR",$_POST['user'],time()+COOKIE_EXPIRE,COOKIE_PATH);
+                        $session->login($_POST['user']);
+                        header("Location: action.php?action=loginAvatar&function=login");
+                }
+        }
 	
 	private function Logout() {
 		global $session,$database;

--- a/core/CSession.php
+++ b/core/CSession.php
@@ -33,42 +33,46 @@ class CSession {
 	public $IsAdvMilitaryActive = false;
 	public $IsAdvDiplomacyActive = false;
 
-	function CSession() {
-		session_start();
-		global $database,$log;
-		$this->logged_in = $this->checkLogin();
-		if($this->logged_in && TRACK_USR) {
-		  $database->updateActiveUser($_SESSION['username'],time());
-		  $this->barbarian = $database->getBarbarianRow($this->uid);
-		 }	  
-		if(isset($_SESSION['url'])){
+        function CSession() {
+                error_log("CSession::__construct start");
+                session_start();
+                global $database,$log;
+                $this->logged_in = $this->checkLogin();
+                if($this->logged_in && TRACK_USR) {
+                  $database->updateActiveUser($_SESSION['username'],time());
+                  $this->barbarian = $database->getBarbarianRow($this->uid);
+                 }
+                if(isset($_SESSION['url'])){
          $this->referrer = $_SESSION['url'];
-		 }else{
-			 $this->referrer = "/";
-		}
-		$this->url = $_SESSION['url'] = $_SERVER['PHP_SELF'];
-		if($this->logged_in){
-		 $this->updateBuildings();
-		 $this->MakeGlobalUpdates();
-		 global $log;
-		 $log->loadAvatarLogs($this->uid);
-		}
-	}
+                 }else{
+                         $this->referrer = "/";
+                }
+                $this->url = $_SESSION['url'] = $_SERVER['PHP_SELF'];
+                if($this->logged_in){
+                 $this->updateBuildings();
+                 $this->MakeGlobalUpdates();
+                 global $log;
+                 $log->loadAvatarLogs($this->uid);
+                }
+                error_log("CSession::__construct completed");
+        }
 	
-	public function Login($user) {
-		global $database,$generator,$log;
-		$this->logged_in = true;
-		$_SESSION['sessid'] = $generator->generateRandID();
-		$_SESSION['username'] = $user;	
-		$_SESSION['checker'] = $generator->generateRandStr(20);
-		$_SESSION['mchecker'] = $generator->generateRandStr(5);
-		$_SESSION['userid'] = $database->getUserField($user,"id",true);
-		$this->PopulateVar();
-		
-		$database->addActiveUser($_SESSION['username'],time());
-		$database->updateUserField($_SESSION['username'],"sessid",$_SESSION['sessid'],0);
-		$log->AddLoginLog($_SESSION['username'],$_SERVER['REMOTE_ADDR'],date("F j, Y, g:i a"));
-	}
+        public function Login($user) {
+                global $database,$generator,$log;
+                error_log("CSession::Login start for user: ".$user);
+                $this->logged_in = true;
+                $_SESSION['sessid'] = $generator->generateRandID();
+                $_SESSION['username'] = $user;
+                $_SESSION['checker'] = $generator->generateRandStr(20);
+                $_SESSION['mchecker'] = $generator->generateRandStr(5);
+                $_SESSION['userid'] = $database->getUserField($user,"id",true);
+                $this->PopulateVar();
+
+                $database->addActiveUser($_SESSION['username'],time());
+                $database->updateUserField($_SESSION['username'],"sessid",$_SESSION['sessid'],0);
+                $log->AddLoginLog($_SESSION['username'],$_SERVER['REMOTE_ADDR'],date("F j, Y, g:i a"));
+                error_log("CSession::Login completed for user: ".$user);
+        }
 	
 	public function Logout() {
 		global $database;


### PR DESCRIPTION
## Summary
- log game launch initialization and request validation in `action.php`
- log login attempts, successes and failures in `CAccount::Login`
- log session construction and login flow in `CSession`

## Testing
- `php -l action.php`
- `php -l core/CAccount.php`
- `php -l core/CSession.php`


------
https://chatgpt.com/codex/tasks/task_e_68920e7149c4832b801c40f96b13ba36