### PR TITLE
Replace .php references with .html in navigation files

### DIFF
--- a/Templates/citynavigator.php
+++ b/Templates/citynavigator.php
@@ -1,10 +1,10 @@
 <?php
 if(!isset($_SESSION['sessid']))
-	header("Location: ../index.php");
+        header("Location: ../index.html");
 
 ?>
 <div id="cityNav">
- <form id="changeCityForm" action="action.php" method="POST">
+ <form id="changeCityForm" action="action.html" method="POST">
   <fieldset style="display: none;">
   <input type="hidden" name="action" value="header" />
   <input type="hidden" name="function" value="changeCurrentCity" />

--- a/Templates/footer.php
+++ b/Templates/footer.php
@@ -2,7 +2,7 @@
 <div id="footer">
 <span class="copyright">&copy; 2010 by <a title="prince 3" id="gflink" target="_blank" href="mailto:khatibe_30@hotmail.fr">prince 3</a>
 <a href="?view=credits" style="margin: 0px;">.</a> كل الحقوق محفوظة.</span>
-<a target="_blank" href="rules.php" title="قواعد">قواعد</a>
+<a target="_blank" href="rules.html" title="قواعد">قواعد</a>
 <a target="_blank" href="" title="شروط الاستخدام">شروط الاستخدام</a>
 <a target="_blank" href="" title="الناشر">الناشر</a>
 <a target="_blank" href="" title="بيان الخصوصية">بيان الخصوصية</a>

--- a/lostpwd.php
+++ b/lostpwd.php
@@ -204,10 +204,10 @@
     <!-- En-tête -->
     <header class="header">
         <div class="nav-container">
-            <a href="index.php" class="logo">EMPIRE</a>
+            <a href="index.html" class="logo">EMPIRE</a>
             <nav class="nav-links">
-                <a href="index.php">Connexion</a>
-                <a href="register.php">Inscription</a>
+                <a href="index.html">Connexion</a>
+                <a href="register.html">Inscription</a>
             </nav>
         </div>
     </header>

--- a/register.html
+++ b/register.html
@@ -211,8 +211,8 @@
     <!-- En-tête -->
     <header class="header">
         <div class="nav-container">
-            <a href="index.php" class="logo">EMPIRE</a>
-            <a href="index.php" class="btn-secondary">Connexion</a>
+            <a href="index.html" class="logo">EMPIRE</a>
+            <a href="index.html" class="btn-secondary">Connexion</a>
         </div>
     </header>
 
@@ -220,8 +220,8 @@
     <main class="main-content">
         <div class="register-form">
             <h3 class="form-title">Créez votre Empire</h3>
-            <!-- Le formulaire envoie les données à register.php, qui doit contenir la logique serveur. -->
-            <form id="RegisterForm" name="RegisterForm" action="register.php" method="post" novalidate>
+            <!-- Le formulaire envoie les données à register.html, qui doit contenir la logique serveur. -->
+            <form id="RegisterForm" name="RegisterForm" action="register.html" method="post" novalidate>
                 <input name="ft" type="hidden" value="a1" />
 
                 <div class="form-group">

--- a/tour_step1.php
+++ b/tour_step1.php
@@ -180,11 +180,11 @@
     <!-- En-tête -->
     <header class="header">
         <div class="nav-container">
-            <a href="index.php" class="logo">EMPIRE</a>
+            <a href="index.html" class="logo">EMPIRE</a>
             <nav class="nav-links">
-                <a href="index.php">Connexion</a>
-                <a href="register.php">Inscription</a>
-                <a href="tour.php" style="color: #fbbf24;">Visite du jeu</a>
+                <a href="index.html">Connexion</a>
+                <a href="register.html">Inscription</a>
+                <a href="tour.html" style="color: #fbbf24;">Visite du jeu</a>
                 <a href="#" target="_blank">Forum</a>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- update navigation links in register, lost password, and tour pages to point to `.html` files
- change city navigator form and footer to use `.html` endpoints instead of `.php`

## Testing
- `php -l Templates/citynavigator.php`
- `php -l Templates/footer.php`
- `php -l lostpwd.php`
- `php -l tour_step1.php`


------
https://chatgpt.com/codex/tasks/task_e_68922690ca90832bb4f4f93dc693ac11