### PR TITLE
feat: grey unavailable actions

### DIFF
--- a/action.html
+++ b/action.html
@@ -468,7 +468,7 @@
            }
 
            // --- FONCTIONS D'AFFICHAGE ---
-           function updateAllUI() { updateResourceUI(); updateQueueUI(); }
+           function updateAllUI() { updateResourceUI(); updateQueueUI(); updateActionAvailability(); }
            function updateResourceUI() { for (const res in dom.res) { if(dom.res[res]) dom.res[res].textContent = Math.floor(gameState.resources[res]); } }
            
            function renderCityLayout() {
@@ -549,6 +549,7 @@
                    }
                }
                dom.contextPanel.innerHTML = html;
+               updateActionAvailability();
            }
 
            function showContextModalForBuilding(plotId) {
@@ -617,6 +618,26 @@
                        li.innerHTML = `<div class="name">${item.name} ${item.level ? `(Niv. ${item.level})` : ''}</div><div class="timer">${new Date(remainingTime * 1000).toISOString().substr(14, 5)}</div>`;
                        dom.queueList.appendChild(li);
                    });
+               });
+           }
+           function updateActionAvailability() {
+               document.querySelectorAll('button[data-action]').forEach(btn => {
+                   const action = btn.dataset.action;
+                   const name = btn.dataset.name;
+                   const level = parseInt(btn.dataset.level) || 1;
+                   let spec, cost;
+                   if (action === 'build') { spec = config.buildings[name]?.levels[level - 1]; }
+                   else if (action === 'research') {
+                       const branch = Object.values(config.research).find(br => br.techs[name]);
+                       spec = branch?.techs[name];
+                   }
+                   else if (action === 'military') { spec = config.units[name]; }
+                   else if (action === 'diplomacy') { spec = config.diplomacy.treaties[name]; }
+                   cost = spec?.cost;
+                   if (cost) {
+                       const enough = Object.entries(cost).every(([res, val]) => (gameState.resources[res] || 0) >= val);
+                       btn.disabled = !enough;
+                   }
                });
            }
            function showModal(action, id, name, level) {


### PR DESCRIPTION
## Summary
- disable action buttons when player lacks required resources
- re-evaluate action availability during UI updates

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923b939b58832b893ea8c435b897ca